### PR TITLE
Changing type of field horaat_rishum

### DIFF
--- a/models/vehicleResponse.go
+++ b/models/vehicleResponse.go
@@ -32,7 +32,7 @@ type VehicleDetails struct {
 			FrontWheel            string  `json:"zmig_kidmi"`
 			RearWheel             string  `json:"zmig_ahori"`
 			FuelType              string  `json:"sug_delek_nm"`
-			RegisterySerialNumber any     `json:"horaat_rishum"`
+			RegistrySerialNumber  any     `json:"horaat_rishum"`
 			FirstOnRoadDate       string  `json:"moed_aliya_lakvish"`
 			CommercialName        string  `json:"kinuy_mishari"`
 			Rank                  float64 `json:"rank"`

--- a/models/vehicleResponse.go
+++ b/models/vehicleResponse.go
@@ -32,7 +32,7 @@ type VehicleDetails struct {
 			FrontWheel            string  `json:"zmig_kidmi"`
 			RearWheel             string  `json:"zmig_ahori"`
 			FuelType              string  `json:"sug_delek_nm"`
-			RegisterySerialNumber int     `json:"horaat_rishum"`
+			RegisterySerialNumber any     `json:"horaat_rishum"`
 			FirstOnRoadDate       string  `json:"moed_aliya_lakvish"`
 			CommercialName        string  `json:"kinuy_mishari"`
 			Rank                  float64 `json:"rank"`


### PR DESCRIPTION
Fixes #9 
This pull request includes a change to the `VehicleDetails` struct in the `models/vehicleResponse.go` file to allow for more flexibility in the data type of the `RegisterySerialNumber` field.