### PR TITLE
Removing the need to translating car manufacturer on the client

### DIFF
--- a/models/vehicleResponse.go
+++ b/models/vehicleResponse.go
@@ -71,5 +71,5 @@ type VehicleResponse struct {
 	FirstOnRoadDate     string `json:"first_on_road_date"`
 	CommercialName      string `json:"commercial_name"`
 	ManufacturerName    string `json:"manufacturer_name"`
-	ManufacturerNameEN  string `json:"manufacturer_name_translation_to_english"`
+	ManufacturerNameEN  string `json:"manufacturer_name_en"`
 }

--- a/models/vehicleResponse.go
+++ b/models/vehicleResponse.go
@@ -71,4 +71,5 @@ type VehicleResponse struct {
 	FirstOnRoadDate     string `json:"first_on_road_date"`
 	CommercialName      string `json:"commercial_name"`
 	ManufacturerName    string `json:"manufacturer_name"`
+	ManufacturerNameEN  string `json:"manufacturer_name_translation_to_english"`
 }

--- a/services/vehicle_service.go
+++ b/services/vehicle_service.go
@@ -68,6 +68,7 @@ func FetchVehicleDetailsByLicensePlate(licensePlate string) (vehicle.VehicleResp
 		FirstOnRoadDate:     record.FirstOnRoadDate,
 		CommercialName:      record.CommercialName,
 		ManufacturerName:    manufacturerCountryAndName[0],
+		ManufacturerNameEN:  utils.TranslateManufacturerNameToEnglish(manufacturerCountryAndName[0]),
 	}
 
 	return vehicleDetails, nil

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -49,7 +49,7 @@ var CarManufacturerNameTranslationToEnglish = map[string]string{
 	"דודג'":             "Dodge",
 	"דונגפנג":           "Dongfeng",
 	"די.אס":             "DS",
-	"דייהו":             "Daewood",
+	"דייהו":             "Daewoo",
 	"דייהטסו":           "Daihatsu",
 	"דיפאל":             "Deepal",
 	"האמר":              "Hummer",
@@ -151,7 +151,7 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 		return "nissan"
 	case "מיצובישי":
 		return "mitsubishi"
-	case "BMW":
+	case "ב.מ.וו":
 		return "bmw"
 	case "מרצדס":
 		return "mercedes-benz"
@@ -246,7 +246,7 @@ func TranslateManufacturerNameToEnglish(manufacturerName string) string {
 		return manufacturerName
 	}
 
-	return manufacturerName
+	return ""
 }
 
 func isEnglish(s string) bool {

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -72,7 +72,7 @@ var carManufacturerNameTranslationToEnglish = map[string]string{
 	"לנד רובר":          "Land Rover",
 	"לקסוס":             "Lexus",
 	"לינקולן":           "Lincoln",
-	"ליפמוטור":          "Leafmotor",
+	"ליפמוטור":          "Leapmotor",
 	"לנצ'יה":            "Lancia",
 	"מזדה":              "Mazda",
 	"מאן":               "Man",
@@ -158,7 +158,7 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 	}
 	unknownManufacturersMu.Unlock()
 
-	return slugifyManufacturerName(manufacturerName)
+	return ""
 }
 
 func TranslateManufacturerNameToEnglish(manufacturerName string) string {

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -7,44 +7,44 @@ import (
 	"unicode"
 )
 
-var CarManufacturerNameTranslationToEnglish = map[string]string{
+var carManufacturerNameTranslationToEnglish = map[string]string{
 	"אאודי":             "Audi",
 	"אבארט":             "Abarth",
 	"אווטאר":            "Avatar",
-	"אוטוביאנקי":         "Autobianchi",
+	"אוטוביאנקי":        "Autobianchi",
 	"איוויס":            "Aiways",
-	"אי.וי.איזי":         "A.V.EZ",
+	"אי.וי.איזי":        "A.V.EZ",
 	"אופל":              "Opel",
 	"אורה":              "Ora",
 	"איווקו":            "Iveco",
 	"אניאוס":            "Ineos",
 	"איסוזו":            "Isuzu",
 	"אינפיניטי":         "Infiniti",
-	"אלפא רומיאו":        "Alfa Romeo",
+	"אלפא רומיאו":       "Alfa Romeo",
 	"אם.ג'י":            "MG",
-	"אסטון מרטין":        "Aston Martin",
-	"אל.אי.וי.סי":        "L.E.V.C",
-	"אל.טי.איי":          "L.T.I",
+	"אסטון מרטין":       "Aston Martin",
+	"אל.אי.וי.סי":       "L.E.V.C",
+	"אל.טי.איי":         "L.T.I",
 	"אלפין":             "Alpine",
-	"אם דאבל יו אם":      "M.W.M",
+	"אם דאבל יו אם":     "M.W.M",
 	"אקורה":             "Acura",
-	"אקס אי וי":          "XEV",
+	"אקס אי וי":         "XEV",
 	"אקספנג":            "XPeng",
 	"ב.מ.וו":            "BMW",
-	"בי.אי.דבאליו":       "B.I.W",
+	"בי.אי.דבאליו":      "B.I.W",
 	"ביואיק":            "Buick",
 	"בנטלי":             "Bentley",
 	"ג'אקו":             "Jaecoo",
-	"ג'י.איי.סי":         "GAC",
-	"ג'י.אם.סי":          "GMC",
+	"ג'י.איי.סי":        "GAC",
+	"ג'י.אם.סי":         "GMC",
 	"ג'ילי":             "Geely",
 	"ג'נסיס":            "Genesis",
 	"גופיל":             "Goupil",
 	"ג'יפ":              "Jeep",
 	"גיאיוואן":          "Gyon",
-	"גרייט וול":          "Great Wall",
-	"ג'יי.איי.סי":        "JAC",
-	"דאבל יו אם מוטורס":  "W.M. Motors",
+	"גרייט וול":         "Great Wall",
+	"ג'יי.איי.סי":       "JAC",
+	"דאבל יו אם מוטורס": "W.M. Motors",
 	"דאצ'יה":            "Dacia",
 	"דודג'":             "Dodge",
 	"דונגפנג":           "Dongfeng",
@@ -67,8 +67,8 @@ var CarManufacturerNameTranslationToEnglish = map[string]string{
 	"יודו":              "Yudo",
 	"לאדה":              "Lada",
 	"לוטוס":             "Lotus",
-	"לינק אנד קו":        "Lynk & Co",
-	"למבורגיני":          "Lamborghini",
+	"לינק אנד קו":       "Lynk & Co",
+	"למבורגיני":         "Lamborghini",
 	"לנד רובר":          "Land Rover",
 	"לקסוס":             "Lexus",
 	"לינקולן":           "Lincoln",
@@ -103,7 +103,7 @@ var CarManufacturerNameTranslationToEnglish = map[string]string{
 	"פיאט":              "Fiat",
 	"פיג'ו":             "Peugeot",
 	"פולסטאר":           "Polestar",
-	"פולקסווגן":          "Volkswagen",
+	"פולקסווגן":         "Volkswagen",
 	"פורד":              "Ford",
 	"פורשה":             "Porsche",
 	"פרארי":             "Ferrari",
@@ -123,6 +123,13 @@ var CarManufacturerNameTranslationToEnglish = map[string]string{
 	"שברולט":            "Chevrolet",
 }
 
+var englishManufacturerToLegacySlug = map[string]string{
+	"Mercedes":    "mercedes-benz",
+	"Alfa Romeo":  "alfa-romeo",
+	"Land Rover":  "land-rover",
+	"Rolls-Royce": "rolls-royce",
+}
+
 var (
 	unknownManufacturersMu sync.Mutex
 	unknownManufacturers   = map[string]struct{}{}
@@ -135,90 +142,13 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 		return ""
 	}
 
-	if isEnglish(manufacturerName) {
-		return strings.ToLower(manufacturerName)
+	if isLatinManufacturerName(manufacturerName) {
+		return slugifyManufacturerName(manufacturerName)
 	}
 
 	normalizedManufacturerName := normalizeManufacturerName(manufacturerName)
-	switch normalizedManufacturerName {
-	case "פורד":
-		return "ford"
-	case "טויוטה":
-		return "toyota"
-	case "הונדה":
-		return "honda"
-	case "ניסאן":
-		return "nissan"
-	case "מיצובישי":
-		return "mitsubishi"
-	case "ב.מ.וו":
-		return "bmw"
-	case "מרצדס":
-		return "mercedes-benz"
-	case "אאודי":
-		return "audi"
-	case "פולקסווגן":
-		return "volkswagen"
-	case "יונדאי":
-		return "hyundai"
-	case "קיה":
-		return "kia"
-	case "מזדה":
-		return "mazda"
-	case "סובארו":
-		return "subaru"
-	case "לקסוס":
-		return "lexus"
-	case "אינפיניטי":
-		return "infiniti"
-	case "וולוו":
-		return "volvo"
-	case "פיאט":
-		return "fiat"
-	case "אלפא רומיאו":
-		return "alfa-romeo"
-	case "פיג'ו":
-		return "peugeot"
-	case "רנו":
-		return "renault"
-	case "סיטרואן":
-		return "citroen"
-	case "סקודה":
-		return "skoda"
-	case "סיאט":
-		return "seat"
-	case "לנד רובר":
-		return "land-rover"
-	case "ג'יפ":
-		return "jeep"
-	case "דודג'":
-		return "dodge"
-	case "שברולט":
-		return "chevrolet"
-	case "קאדילק":
-		return "cadillac"
-	case "לינקולן":
-		return "lincoln"
-	case "פורשה":
-		return "porsche"
-	case "מיני":
-		return "mini"
-	case "יגואר":
-		return "jaguar"
-	case "בנטלי":
-		return "bentley"
-	case "רולס רויס":
-		return "rolls-royce"
-	case "מזראטי":
-		return "maserati"
-	case "למבורגיני":
-		return "lamborghini"
-	case "פרארי":
-		return "ferrari"
-	case "אופל":
-		return "opel"
-	case "דאצ'יה":
-		return "dacia"
+	if translatedName, found := carManufacturerNameTranslationToEnglish[normalizedManufacturerName]; found {
+		return slugifyManufacturerName(translatedName)
 	}
 
 	unknownManufacturersMu.Lock()
@@ -228,7 +158,7 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 	}
 	unknownManufacturersMu.Unlock()
 
-	return strings.ToLower(manufacturerName)
+	return slugifyManufacturerName(manufacturerName)
 }
 
 func TranslateManufacturerNameToEnglish(manufacturerName string) string {
@@ -238,24 +168,58 @@ func TranslateManufacturerNameToEnglish(manufacturerName string) string {
 	}
 
 	normalizedManufacturerName := normalizeManufacturerName(manufacturerName)
-	if translatedName, found := CarManufacturerNameTranslationToEnglish[normalizedManufacturerName]; found {
+	if translatedName, found := carManufacturerNameTranslationToEnglish[normalizedManufacturerName]; found {
 		return translatedName
 	}
 
-	if isEnglish(manufacturerName) {
+	if isLatinManufacturerName(manufacturerName) {
 		return manufacturerName
 	}
 
 	return ""
 }
 
-func isEnglish(s string) bool {
+func isLatinManufacturerName(s string) bool {
+	hasLatinLetter := false
 	for _, r := range s {
-		if r > unicode.MaxASCII {
+		switch {
+		case unicode.IsLetter(r):
+			if !unicode.In(r, unicode.Latin) {
+				return false
+			}
+			hasLatinLetter = true
+		case unicode.IsDigit(r):
+			continue
+		case unicode.IsSpace(r):
+			continue
+		case strings.ContainsRune("&-.'/", r):
+			continue
+		default:
 			return false
 		}
 	}
-	return true
+	return hasLatinLetter
+}
+
+func slugifyManufacturerName(manufacturerName string) string {
+	if slug, found := englishManufacturerToLegacySlug[manufacturerName]; found {
+		return slug
+	}
+
+	slug := strings.ToLower(strings.TrimSpace(manufacturerName))
+	slug = strings.ReplaceAll(slug, "&", " and ")
+	slug = strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			return r
+		case unicode.IsSpace(r), r == '-', r == '.', r == '\'' || r == '/':
+			return '-'
+		default:
+			return -1
+		}
+	}, slug)
+
+	return strings.Join(strings.FieldsFunc(slug, func(r rune) bool { return r == '-' }), "-")
 }
 
 func normalizeManufacturerName(manufacturerName string) string {

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -142,13 +142,13 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 		return ""
 	}
 
-	if isLatinManufacturerName(manufacturerName) {
-		return slugifyManufacturerName(manufacturerName)
+	translatedName := TranslateManufacturerNameToEnglish(manufacturerName)
+	if translatedName != "" {
+		return slugifyManufacturerName(translatedName)
 	}
 
-	normalizedManufacturerName := normalizeManufacturerName(manufacturerName)
-	if translatedName, found := carManufacturerNameTranslationToEnglish[normalizedManufacturerName]; found {
-		return slugifyManufacturerName(translatedName)
+	if !containsLetterOrDigit(manufacturerName) {
+		return ""
 	}
 
 	unknownManufacturersMu.Lock()
@@ -190,6 +190,16 @@ func isLatinManufacturerName(s string) bool {
 		}
 	}
 	return hasLatinLetter
+}
+
+func containsLetterOrDigit(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func slugifyManufacturerName(manufacturerName string) string {

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -124,10 +124,10 @@ var carManufacturerNameTranslationToEnglish = map[string]string{
 }
 
 var englishManufacturerToLegacySlug = map[string]string{
-	"Mercedes":    "mercedes-benz",
-	"Alfa Romeo":  "alfa-romeo",
-	"Land Rover":  "land-rover",
-	"Rolls-Royce": "rolls-royce",
+	"mercedes":    "mercedes-benz",
+	"alfa romeo":  "alfa-romeo",
+	"land rover":  "land-rover",
+	"rolls-royce": "rolls-royce",
 }
 
 var (
@@ -154,7 +154,7 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 	unknownManufacturersMu.Lock()
 	if _, seen := unknownManufacturers[manufacturerName]; !seen {
 		unknownManufacturers[manufacturerName] = struct{}{}
-		log.Printf("ConvertManufacturerToEnglish: unmapped Hebrew manufacturer: %q — consider adding translation support", manufacturerName)
+		log.Printf("ConvertManufacturerToEnglish: unmapped manufacturer: %q — consider adding translation support", manufacturerName)
 	}
 	unknownManufacturersMu.Unlock()
 
@@ -182,31 +182,23 @@ func TranslateManufacturerNameToEnglish(manufacturerName string) string {
 func isLatinManufacturerName(s string) bool {
 	hasLatinLetter := false
 	for _, r := range s {
-		switch {
-		case unicode.IsLetter(r):
+		if unicode.IsLetter(r) {
 			if !unicode.In(r, unicode.Latin) {
 				return false
 			}
 			hasLatinLetter = true
-		case unicode.IsDigit(r):
-			continue
-		case unicode.IsSpace(r):
-			continue
-		case strings.ContainsRune("&-.'/", r):
-			continue
-		default:
-			return false
 		}
 	}
 	return hasLatinLetter
 }
 
 func slugifyManufacturerName(manufacturerName string) string {
-	if slug, found := englishManufacturerToLegacySlug[manufacturerName]; found {
+	normalizedManufacturerName := strings.ToLower(strings.TrimSpace(manufacturerName))
+	if slug, found := englishManufacturerToLegacySlug[normalizedManufacturerName]; found {
 		return slug
 	}
 
-	slug := strings.ToLower(strings.TrimSpace(manufacturerName))
+	slug := normalizedManufacturerName
 	slug = strings.ReplaceAll(slug, "&", " and ")
 	slug = strings.Map(func(r rune) rune {
 		switch {

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -7,49 +7,120 @@ import (
 	"unicode"
 )
 
-var HebrewToEnglishManufacturerMap = map[string]string{
-	"פורד":           "ford",
-	"טויוטה":         "toyota",
-	"הונדה":          "honda",
-	"ניסאן":          "nissan",
-	"ניסן":           "nissan",
-	"מיצובישי":        "mitsubishi",
-	"מיצובישי-פוג'ו":   "mitsubishi",
-	"BMW":            "bmw",
-	"מרצדס":          "mercedes-benz",
-	"מרצדס-בנץ":       "mercedes-benz",
-	"אאודי":          "audi",
-	"פולקסווגן":       "volkswagen",
-	"יונדאי":         "hyundai",
-	"קיה":            "kia",
-	"מזדה":           "mazda",
-	"סובארו":         "subaru",
-	"לקסוס":          "lexus",
-	"אינפיניטי":       "infiniti",
-	"וולוו":          "volvo",
-	"פיאט":           "fiat",
-	"אלפא רומיאו":     "alfa-romeo",
-	"פיג'ו":          "peugeot",
-	"רנו":            "renault",
-	"סיטרואן":        "citroen",
-	"סקודה":          "skoda",
-	"סיאט":           "seat",
-	"לנד רובר":       "land-rover",
-	"ג'יפ":           "jeep",
-	"דודג'":          "dodge",
-	"שברולט":         "chevrolet",
-	"קדילאק":         "cadillac",
-	"לינקולן":        "lincoln",
-	"פורשה":          "porsche",
-	"מיני":           "mini",
-	"יגואר":          "jaguar",
-	"בנטלי":          "bentley",
-	"רולס רויס":      "rolls-royce",
-	"מזראטי":         "maserati",
-	"למבורגיני":      "lamborghini",
-	"פרארי":          "ferrari",
-	"אופל":           "opel",
-	"דאציה":          "dacia",
+var CarManufacturerNameTranslationToEnglish = map[string]string{
+	"אאודי":             "Audi",
+	"אבארט":             "Abarth",
+	"אווטאר":            "Avatar",
+	"אוטוביאנקי":         "Autobianchi",
+	"איוויס":            "Aiways",
+	"אי.וי.איזי":         "A.V.EZ",
+	"אופל":              "Opel",
+	"אורה":              "Ora",
+	"איווקו":            "Iveco",
+	"אניאוס":            "Ineos",
+	"איסוזו":            "Isuzu",
+	"אינפיניטי":         "Infiniti",
+	"אלפא רומיאו":        "Alfa Romeo",
+	"אם.ג'י":            "MG",
+	"אסטון מרטין":        "Aston Martin",
+	"אל.אי.וי.סי":        "L.E.V.C",
+	"אל.טי.איי":          "L.T.I",
+	"אלפין":             "Alpine",
+	"אם דאבל יו אם":      "M.W.M",
+	"אקורה":             "Acura",
+	"אקס אי וי":          "XEV",
+	"אקספנג":            "XPeng",
+	"ב.מ.וו":            "BMW",
+	"בי.אי.דבאליו":       "B.I.W",
+	"ביואיק":            "Buick",
+	"בנטלי":             "Bentley",
+	"ג'אקו":             "Jaecoo",
+	"ג'י.איי.סי":         "GAC",
+	"ג'י.אם.סי":          "GMC",
+	"ג'ילי":             "Geely",
+	"ג'נסיס":            "Genesis",
+	"גופיל":             "Goupil",
+	"ג'יפ":              "Jeep",
+	"גיאיוואן":          "Gyon",
+	"גרייט וול":          "Great Wall",
+	"ג'יי.איי.סי":        "JAC",
+	"דאבל יו אם מוטורס":  "W.M. Motors",
+	"דאצ'יה":            "Dacia",
+	"דודג'":             "Dodge",
+	"דונגפנג":           "Dongfeng",
+	"די.אס":             "DS",
+	"דייהו":             "Daewood",
+	"דייהטסו":           "Daihatsu",
+	"דיפאל":             "Deepal",
+	"האמר":              "Hummer",
+	"הונגצ'י":           "Hongqi",
+	"הונדה":             "Honda",
+	"וויה":              "Voyah",
+	"ווי":               "Wey",
+	"וולוו":             "Volvo",
+	"זיקר":              "Zeekr",
+	"טאטא":              "Tata",
+	"טויוטה":            "Toyota",
+	"טסלה":              "Tesla",
+	"יגואר":             "Jaguar",
+	"יונדאי":            "Hyundai",
+	"יודו":              "Yudo",
+	"לאדה":              "Lada",
+	"לוטוס":             "Lotus",
+	"לינק אנד קו":        "Lynk & Co",
+	"למבורגיני":          "Lamborghini",
+	"לנד רובר":          "Land Rover",
+	"לקסוס":             "Lexus",
+	"לינקולן":           "Lincoln",
+	"ליפמוטור":          "Leafmotor",
+	"לנצ'יה":            "Lancia",
+	"מזדה":              "Mazda",
+	"מאן":               "Man",
+	"מורגן":             "Morgan",
+	"מזראטי":            "Maserati",
+	"מיני":              "Mini",
+	"מיצובישי":          "Mitsubishi",
+	"מקלארן":            "McLaren",
+	"מקסוס":             "Maxus",
+	"מרצדס":             "Mercedes",
+	"נטע":               "Neta",
+	"ניאו":              "Nio",
+	"ניסאן":             "Nissan",
+	"ננג'ינג":           "Nanjing",
+	"סאאב":              "Saab",
+	"סאנגיונג":          "Sangyong",
+	"סאנשיין":           "Sunshine",
+	"סובארו":            "Subaru",
+	"סוזוקי":            "Suzuki",
+	"סיטרואן":           "Citroen",
+	"סיאט":              "Seat",
+	"סקודה":             "Skoda",
+	"סרס":               "Seres",
+	"סמארט":             "Smart",
+	"סנטרו":             "Santro",
+	"סקיוול":            "Skywell",
+	"פוטון":             "Foton",
+	"פיאט":              "Fiat",
+	"פיג'ו":             "Peugeot",
+	"פולסטאר":           "Polestar",
+	"פולקסווגן":          "Volkswagen",
+	"פורד":              "Ford",
+	"פורשה":             "Porsche",
+	"פרארי":             "Ferrari",
+	"פורתינג":           "Forthing",
+	"פיאג'ו":            "Piaggio",
+	"צ'רי":              "Chery",
+	"קאדילק":            "Cadillac",
+	"קארמה":             "Karma",
+	"קיה":               "Kia",
+	"קופרה":             "Cupra",
+	"קרייזלר":           "Chrysler",
+	"ראם":               "Ram",
+	"רובר":              "Rover",
+	"רנו":               "Renault",
+	"ריהיי":             "Reyee",
+	"רולס רויס":         "Rolls-Royce",
+	"שברולט":            "Chevrolet",
 }
 
 var (
@@ -68,18 +139,114 @@ func ConvertManufacturerToEnglish(manufacturerName string) string {
 		return strings.ToLower(manufacturerName)
 	}
 
-	if englishName, found := HebrewToEnglishManufacturerMap[manufacturerName]; found {
-		return strings.ToLower(englishName)
+	normalizedManufacturerName := normalizeManufacturerName(manufacturerName)
+	switch normalizedManufacturerName {
+	case "פורד":
+		return "ford"
+	case "טויוטה":
+		return "toyota"
+	case "הונדה":
+		return "honda"
+	case "ניסאן":
+		return "nissan"
+	case "מיצובישי":
+		return "mitsubishi"
+	case "BMW":
+		return "bmw"
+	case "מרצדס":
+		return "mercedes-benz"
+	case "אאודי":
+		return "audi"
+	case "פולקסווגן":
+		return "volkswagen"
+	case "יונדאי":
+		return "hyundai"
+	case "קיה":
+		return "kia"
+	case "מזדה":
+		return "mazda"
+	case "סובארו":
+		return "subaru"
+	case "לקסוס":
+		return "lexus"
+	case "אינפיניטי":
+		return "infiniti"
+	case "וולוו":
+		return "volvo"
+	case "פיאט":
+		return "fiat"
+	case "אלפא רומיאו":
+		return "alfa-romeo"
+	case "פיג'ו":
+		return "peugeot"
+	case "רנו":
+		return "renault"
+	case "סיטרואן":
+		return "citroen"
+	case "סקודה":
+		return "skoda"
+	case "סיאט":
+		return "seat"
+	case "לנד רובר":
+		return "land-rover"
+	case "ג'יפ":
+		return "jeep"
+	case "דודג'":
+		return "dodge"
+	case "שברולט":
+		return "chevrolet"
+	case "קאדילק":
+		return "cadillac"
+	case "לינקולן":
+		return "lincoln"
+	case "פורשה":
+		return "porsche"
+	case "מיני":
+		return "mini"
+	case "יגואר":
+		return "jaguar"
+	case "בנטלי":
+		return "bentley"
+	case "רולס רויס":
+		return "rolls-royce"
+	case "מזראטי":
+		return "maserati"
+	case "למבורגיני":
+		return "lamborghini"
+	case "פרארי":
+		return "ferrari"
+	case "אופל":
+		return "opel"
+	case "דאצ'יה":
+		return "dacia"
 	}
 
 	unknownManufacturersMu.Lock()
 	if _, seen := unknownManufacturers[manufacturerName]; !seen {
 		unknownManufacturers[manufacturerName] = struct{}{}
-		log.Printf("ConvertManufacturerToEnglish: unmapped Hebrew manufacturer: %q — consider adding to HebrewToEnglishManufacturerMap", manufacturerName)
+		log.Printf("ConvertManufacturerToEnglish: unmapped Hebrew manufacturer: %q — consider adding translation support", manufacturerName)
 	}
 	unknownManufacturersMu.Unlock()
 
 	return strings.ToLower(manufacturerName)
+}
+
+func TranslateManufacturerNameToEnglish(manufacturerName string) string {
+	manufacturerName = strings.TrimSpace(manufacturerName)
+	if manufacturerName == "" {
+		return ""
+	}
+
+	normalizedManufacturerName := normalizeManufacturerName(manufacturerName)
+	if translatedName, found := CarManufacturerNameTranslationToEnglish[normalizedManufacturerName]; found {
+		return translatedName
+	}
+
+	if isEnglish(manufacturerName) {
+		return manufacturerName
+	}
+
+	return manufacturerName
 }
 
 func isEnglish(s string) bool {
@@ -89,4 +256,21 @@ func isEnglish(s string) bool {
 		}
 	}
 	return true
+}
+
+func normalizeManufacturerName(manufacturerName string) string {
+	switch manufacturerName {
+	case "ניסן":
+		return "ניסאן"
+	case "מיצובישי-פוג'ו":
+		return "מיצובישי"
+	case "מרצדס-בנץ":
+		return "מרצדס"
+	case "קדילאק":
+		return "קאדילק"
+	case "דאציה":
+		return "דאצ'יה"
+	default:
+		return manufacturerName
+	}
 }

--- a/utils/manufacturer_mapping.go
+++ b/utils/manufacturer_mapping.go
@@ -88,7 +88,7 @@ var carManufacturerNameTranslationToEnglish = map[string]string{
 	"ניסאן":             "Nissan",
 	"ננג'ינג":           "Nanjing",
 	"סאאב":              "Saab",
-	"סאנגיונג":          "Sangyong",
+	"סאנגיונג":          "SsangYong",
 	"סאנשיין":           "Sunshine",
 	"סובארו":            "Subaru",
 	"סוזוקי":            "Suzuki",

--- a/utils/manufacturer_mapping_test.go
+++ b/utils/manufacturer_mapping_test.go
@@ -20,8 +20,8 @@ func TestTranslateManufacturerNameToEnglish(t *testing.T) {
 		},
 		{
 			name:  "keeps latin names with diacritics",
-			input: "Peugéot",
-			want:  "Peugéot",
+			input: "Citroën",
+			want:  "Citroën",
 		},
 		{
 			name:  "returns empty for unmapped non latin",

--- a/utils/manufacturer_mapping_test.go
+++ b/utils/manufacturer_mapping_test.go
@@ -1,0 +1,89 @@
+package utils
+
+import "testing"
+
+func TestTranslateManufacturerNameToEnglish(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "translates known hebrew brand",
+			input: "טויוטה",
+			want:  "Toyota",
+		},
+		{
+			name:  "normalizes alias before translation",
+			input: "דאציה",
+			want:  "Dacia",
+		},
+		{
+			name:  "keeps latin names with diacritics",
+			input: "Peugéot",
+			want:  "Peugéot",
+		},
+		{
+			name:  "returns empty for unmapped non latin",
+			input: "יצרן-לא-מוכר",
+			want:  "",
+		},
+		{
+			name:  "correct leapmotor spelling",
+			input: "ליפמוטור",
+			want:  "Leapmotor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TranslateManufacturerNameToEnglish(tt.input)
+			if got != tt.want {
+				t.Fatalf("TranslateManufacturerNameToEnglish(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertManufacturerToEnglish(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "slugifies mapped hebrew manufacturer",
+			input: "טויוטה",
+			want:  "toyota",
+		},
+		{
+			name:  "uses legacy slug override",
+			input: "מרצדס",
+			want:  "mercedes-benz",
+		},
+		{
+			name:  "slugifies latin manufacturer with symbols",
+			input: "Lynk & Co",
+			want:  "lynk-and-co",
+		},
+		{
+			name:  "returns empty for unmapped hebrew manufacturer",
+			input: "יצרן-לא-מוכר",
+			want:  "",
+		},
+		{
+			name:  "returns empty for symbol only input",
+			input: "///",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertManufacturerToEnglish(tt.input)
+			if got != tt.want {
+				t.Fatalf("ConvertManufacturerToEnglish(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #20 

This pull request enhances the handling and translation of car manufacturer names, especially for Hebrew names, by introducing a more comprehensive and maintainable mapping system. It adds a new English translation for manufacturer names in vehicle responses, improves normalization of manufacturer names, and separates concerns between normalization and translation logic.

**Vehicle response improvements:**
- Added a new field `ManufacturerNameEN` to the `VehicleResponse` struct to store the English translation of the manufacturer name.
- Updated the `FetchVehicleDetailsByLicensePlate` service to populate the new `ManufacturerNameEN` field using a dedicated translation utility.

**Translation and normalization logic:**
- Replaced the old `HebrewToEnglishManufacturerMap` with a new, more extensive `CarManufacturerNameTranslationToEnglish` map for translating Hebrew manufacturer names to English.
- Added the `TranslateManufacturerNameToEnglish` function, which uses the new mapping and handles normalization and English detection.
- Introduced the `normalizeManufacturerName` function to standardize input names before translation, improving consistency and handling of common variants.

**Legacy code adjustments:**
- Refactored `ConvertManufacturerToEnglish` to use normalization and a switch statement for legacy (lowercase, slug-style) mappings, and updated logging for unmapped manufacturers.